### PR TITLE
load-grunt-tasks must be listed as a dependency, not devDependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,12 @@
   "bugs": {
     "url": "https://github.com/DavidSouther/grunt-recurse/issues"
   },
+  "dependencies": {
+    "load-grunt-tasks": "~1.0.0"
+  },
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-copy": "~0.4.1",
-    "grunt-release": "~0.6.0",
-    "load-grunt-tasks": "~1.0.0"
+    "grunt-release": "~0.6.0"
   }
 }


### PR DESCRIPTION
We are using grunt-recurse here at Novus still.  However, we keep running into a 'cannot load load-grunt-tasks' error when running our build.  We figured it was because load-grunt-tasks was not listed as a dependency in grunt-recurse's package.json file.  This PR update package.json.